### PR TITLE
Fix capitalization of boot file names

### DIFF
--- a/PUP/Conf/bootdirectory.txt
+++ b/PUP/Conf/bootdirectory.txt
@@ -1,4 +1,4 @@
-﻿# bootdirectory.txt:
+# bootdirectory.txt:
 #
 # This file contains a simple mapping from boot number to boot file, one entry per line
 # in the form:
@@ -16,50 +16,50 @@
 3		scavenger.boot
 4		copydisk.boot
 5		crttest.boot
-6		madtest.boot
-7		chat.boot
+6		MadTest.boot
+7		Chat.boot
 10		netexec.boot
 11		puptest.boot
-12		etherwatch.boot
-13		keytest.boot
-14		calculator.boot
+12		EtherWatch.boot
+13		KeyTest.boot
+14		Calculator.boot
 15		diex.boot
-16		triex.boot
-17		edp.boot
+16		TriEx.boot
+17		EDP.boot
 20		bfstest.boot
 21		gatecontrol.boot
-22		etherload.boot
-24		neptune.boot
+22		EtherLoad.boot
+24		Neptune.boot
 25		what.boot
-40		pupwatch.boot
+40		Pupwatch.boot
 
 # past this point are more esoteric things, here because they're cool
-100		mesanetexec.boot
-200		cedarnetexec.boot
-1000	showais.boot
-1001	starwars.boot
-1002	fly.boot
-1003	kal.boot
-1004	pinball.boot
-1005	pool.boot
-1006	mazewar.boot
-1007	trek.boot
-1010	invaders.boot
+100		MesaNetExec.boot
+200		CedarNetExec.boot
+1000	ShowAIS.boot
+1001	StarWars.boot
+1002	Fly.boot
+1003	Kal.boot
+1004	PinBall.boot
+1005	Pool.boot
+1006	MazeWar.boot
+1007	Trek.boot
+1010	Invaders.boot
 1011	astroroids.boot
-1012	1012.boot
-1013	clock.boot
-1014	galaxian.boot
-1015	ppong.boot
-1016    1006.boot
-1017	messenger.boot
-1020	reversi.boot
-1021	1000.boot
-1023	missilecommand.boot
-40000   boggs.boot
+1012	1012.Boot
+1013	Clock.boot
+1014	Galaxian.boot
+1015	PPong.boot
+1016    1006.Boot
+1017	Messenger.boot
+1020	Reversi.boot
+1021	1000.Boot
+1023	MissileCommand.boot
+40000   Boggs.boot
 40002   murray.boot
-40003   johnsson.boot
+40003   Johnsson.boot
 
-43000   alphamesamesanetexec.boot
+43000   AlphaMesaMesaNetExec.boot
 
 
 


### PR DESCRIPTION
On Windows, the capitalization doesn't matter, but on Linux it does.
This change makes the file names in bootdirectory.txt match the actual file names.
This change allows booting from files with names containing capital letters when using Linux (e.g. BeagleBone Ethernet gateway).