### PR TITLE
Added Missing Thread Termination.

### DIFF
--- a/PUP/Entrypoint.cs
+++ b/PUP/Entrypoint.cs
@@ -46,8 +46,6 @@ namespace IFS
             // Shut things down
             Console.WriteLine("Shutting down, please wait...");
             Router.Instance.Shutdown();
-
-            Environment.Exit(0);
         }
 
         private static void PrintHerald()

--- a/PUP/Entrypoint.cs
+++ b/PUP/Entrypoint.cs
@@ -47,6 +47,7 @@ namespace IFS
             Console.WriteLine("Shutting down, please wait...");
             Router.Instance.Shutdown();
 
+            Environment.Exit(0);
         }
 
         private static void PrintHerald()

--- a/PUP/Gateway/GatewayInformationProtocol.cs
+++ b/PUP/Gateway/GatewayInformationProtocol.cs
@@ -63,6 +63,14 @@ namespace IFS.Gateway
             }
         }
 
+        public override void Terminate()
+        {
+            if (_gatewayInfoThread.IsAlive)
+            {
+                _gatewayInfoThread.Abort();
+            }
+        }
+
         private void SendGatewayInformationResponse(PUP p)
         {
             //

--- a/PUP/Gateway/Router.cs
+++ b/PUP/Gateway/Router.cs
@@ -105,10 +105,12 @@ namespace IFS.Gateway
                 _gatewayUdpClientLock.ExitWriteLock();
             }
 
-            if (_gatewayReceiveThread.IsAlive)
-            {
-                _gatewayReceiveThread.Abort();
-            }
+            try {
+                if (_gatewayReceiveThread.IsAlive)
+                {
+                    _gatewayReceiveThread.Abort();
+                }
+            } catch (System.NullReferenceException) {}
         }
 
         public void RegisterRAWInterface(LivePacketDevice iface)

--- a/PUP/Gateway/Router.cs
+++ b/PUP/Gateway/Router.cs
@@ -104,6 +104,11 @@ namespace IFS.Gateway
                 _gatewayUdpClient.Close();
                 _gatewayUdpClientLock.ExitWriteLock();
             }
+
+            if (_gatewayReceiveThread.IsAlive)
+            {
+                _gatewayReceiveThread.Abort();
+            }
         }
 
         public void RegisterRAWInterface(LivePacketDevice iface)
@@ -337,6 +342,17 @@ namespace IFS.Gateway
                 try
                 {
                     data = _gatewayUdpClient.Receive(ref groupEndPoint);
+                }
+                catch(ThreadAbortException)
+                {
+                    break;
+                }
+                catch(System.ObjectDisposedException)
+                {
+                    Log.Write(LogType.Warning,
+                        LogComponent.Routing,
+                        "The UDP Client was disposed of. Ending gateway receive thread.");
+                    break;
                 }
                 catch(Exception e)
                 {

--- a/PUP/PUPProtocolBase.cs
+++ b/PUP/PUPProtocolBase.cs
@@ -86,6 +86,11 @@ namespace IFS
         /// <param name="p"></param>
         public abstract void RecvData(PUP p);
 
+        /// <summary>
+        /// Called by dispatcher when server shuts down.
+        /// </summary>
+        public virtual void Terminate() {}
+
     }
 
 }

--- a/PUP/PUPProtocolDispatcher.cs
+++ b/PUP/PUPProtocolDispatcher.cs
@@ -46,7 +46,13 @@ namespace IFS
         {
             _breathOfLifeServer.Shutdown();
             BSPManager.Shutdown();
-            //EFTPManager.Shutdown();
+            EFTPManager.Shutdown();
+            foreach (KeyValuePair<uint, PUPProtocolEntry> entry in _dispatchMap) {
+                if(entry.Value.ConnectionType == ConnectionType.Connectionless)
+                {
+                    entry.Value.ProtocolImplementation.Terminate();
+                }
+            }
         }                    
 
         public void ReceivePUP(PUP pup)


### PR DESCRIPTION
This pr adds some missing thread terminations (makes #10 obsolete) which allows the IFS program to terminate and also adds a [ObjectDisposedException ](https://docs.microsoft.com/en-us/dotnet/api/system.objectdisposedexception?view=net-5.0) catch statement to the GatewayReceiveThread in case the UDF Client is disposed of.